### PR TITLE
Enable DMABUF support for ROCm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -247,6 +247,13 @@ AC_ARG_ENABLE([rocm],
               [],
               [enable_rocm=no])
 
+AC_ARG_ENABLE([rocm_dmabuf],
+              [AS_HELP_STRING([--enable-rocm-dmabuf],
+                              [Enable ROCm DMABUF feature])
+              ],
+              [],
+              [enable_rocm_dmabuf=no])
+
 AC_ARG_WITH([rocm],
             [AS_HELP_STRING([--with-rocm=@<:@ROCm installation path@:>@],
                             [Provide path to ROCm installation])
@@ -254,7 +261,7 @@ AC_ARG_WITH([rocm],
             [AS_CASE([$with_rocm],
                      [yes|no], [],
                      [CPPFLAGS="-I$with_rocm/include $CPPFLAGS"
-                      LDFLAGS="-L$with_rocm/lib64 -Wl,-rpath=$with_rocm/lib64 -L$with_rocm/lib -Wl,-rpath=$with_rocm/lib -lamdhip64 $LDFLAGS"])
+                      LDFLAGS="-L$with_rocm/lib64 -Wl,-rpath=$with_rocm/lib64 -L$with_rocm/lib -Wl,-rpath=$with_rocm/lib -lamdhip64 -lhsa-runtime64 $LDFLAGS"])
             ])
 
 AS_IF([test "x$enable_rocm" = xyes], [
@@ -269,6 +276,11 @@ AS_IF([test "x$enable_rocm" = xyes], [
        ])
 
 AM_CONDITIONAL([ROCM], [test x$enable_rocm = xyes])
+
+AS_IF([test "x$enable_rocm_dmabuf" = xyes] && [test "x$HAVE_REG_DMABUF_MR" = "xyes"], [
+	   AC_DEFINE([HAVE_ROCM_DMABUF], [1], [Enable ROCm DMABUF feature])
+	   AC_CHECK_FUNCS([hsa_amd_portable_export_dmabuf])
+	   ])
 
 AC_TRY_LINK([
 #include <infiniband/verbs.h>],

--- a/configure.ac
+++ b/configure.ac
@@ -260,7 +260,7 @@ AC_ARG_WITH([rocm],
             ],
             [AS_CASE([$with_rocm],
                      [yes|no], [],
-                     [CPPFLAGS="-I$with_rocm/include $CPPFLAGS"
+                     [CPPFLAGS="-I$with_rocm/include -I$with_rocm/include/hsa $CPPFLAGS"
                       LDFLAGS="-L$with_rocm/lib64 -Wl,-rpath=$with_rocm/lib64 -L$with_rocm/lib -Wl,-rpath=$with_rocm/lib -lamdhip64 -lhsa-runtime64 $LDFLAGS"])
             ])
 
@@ -277,9 +277,16 @@ AS_IF([test "x$enable_rocm" = xyes], [
 
 AM_CONDITIONAL([ROCM], [test x$enable_rocm = xyes])
 
-AS_IF([test "x$enable_rocm_dmabuf" = xyes] && [test "x$HAVE_REG_DMABUF_MR" = "xyes"], [
-	   AC_DEFINE([HAVE_ROCM_DMABUF], [1], [Enable ROCm DMABUF feature])
-	   AC_CHECK_FUNCS([hsa_amd_portable_export_dmabuf])
+AS_IF([test "x$enable_rocm_dmabuf" = xyes], [
+       AS_IF([test "x$HAVE_REG_DMABUF_MR" = "xno"],
+             [AC_MSG_ERROR([rdma-core doesn't support dmabuf mr registration])])
+       AS_IF([test "x$enable_rocm" = "xno"],
+             [AC_MSG_ERROR([rocm not enabled/supported])])
+       AC_CHECK_HEADERS([hsa/hsa_ext_amd.h], [],
+                        [AC_MSG_ERROR([cannot include hsa/hsa_ext_amd.h])])
+       AC_SEARCH_LIBS([hsa_amd_portable_export_dmabuf], [hsa-runtime64], [],
+                      [AC_MSG_ERROR([cannot link with -lhsa-runtime64])])
+       AC_DEFINE([HAVE_ROCM_DMABUF], [1], [Enable ROCm DMABUF feature])
 	   ])
 
 AC_TRY_LINK([

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -575,6 +575,7 @@ struct perftest_parameters {
 	int				use_cuda_dmabuf;
 	int				use_data_direct;
 	int				rocm_device_id;
+	int				use_rocm_dmabuf;
 	int				neuron_core_id;
 	int				use_neuron_dmabuf;
 	char				*hl_device_bus_id;

--- a/src/rocm_memory.c
+++ b/src/rocm_memory.c
@@ -114,6 +114,10 @@ int rocm_memory_init(struct memory_ctx *ctx) {
 			}
 		}
 		fclose(fp);
+
+		if (dmabuf_supported == 0) {
+			return FAILURE;
+		}
 	}
 #endif
 
@@ -153,7 +157,7 @@ int rocm_memory_allocate_buffer(struct memory_ctx *ctx, int alignment, uint64_t 
 		offset = d_A - aligned_ptr;
 		aligned_size = (size + offset + host_page_size - 1) & ~(host_page_size - 1);
 
-		printf("using DMA-BUF for GPU buffer address at %#llx aligned at %#llx with aligned size %zu\n", d_A, aligned_ptr, aligned_size);
+		printf("using DMA-BUF for GPU buffer address at %p aligned at %p with aligned size %zu\n", d_A, aligned_ptr, aligned_size);
 		*dmabuf_fd = 0;
 
 		status = hsa_amd_portable_export_dmabuf(d_A, aligned_size, dmabuf_fd, &offset);

--- a/src/rocm_memory.c
+++ b/src/rocm_memory.c
@@ -1,17 +1,21 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /*
  * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2024 Advanced Micro Devices, Inc. All rights reserved.
  */
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <sys/utsname.h>
 #include "rocm_memory.h"
 #include <hip/hip_runtime_api.h>
 #if defined HAVE_HIP_HIP_VERSION_H
 #include <hip/hip_version.h>
 #endif
 #include "perftest_parameters.h"
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
 
 #define ROCM_CHECK(stmt)			\
 	do {					\
@@ -25,6 +29,7 @@
 struct rocm_memory_ctx {
 	struct memory_ctx base;
 	int device_id;
+	bool use_dmabuf;
 };
 
 
@@ -69,6 +74,49 @@ int rocm_memory_init(struct memory_ctx *ctx) {
 		fprintf(stderr, "Couldn't initialize ROCm device\n");
 		return FAILURE;
 	}
+
+#ifdef HAVE_ROCM_DMABUF
+	if (rocm_ctx->use_dmabuf) {
+		int dmabuf_supported = 0;
+		const char kernel_opt1[] = "CONFIG_DMABUF_MOVE_NOTIFY=y";
+		const char kernel_opt2[] = "CONFIG_PCI_P2PDMA=y";
+		int found_opt1           = 0;
+		int found_opt2           = 0;
+		FILE *fp;
+		struct utsname utsname;
+		char kernel_conf_file[128];
+		char buf[256];
+
+		if (uname(&utsname) == -1) {
+			printf("could not get kernel name");
+			return FAILURE;
+		}
+
+		snprintf(kernel_conf_file, sizeof(kernel_conf_file),
+						"/boot/config-%s", utsname.release);
+		fp = fopen(kernel_conf_file, "r");
+		if (fp == NULL) {
+			printf("could not open kernel conf file %s error: %m",
+					kernel_conf_file);
+			return FAILURE;
+		}
+
+		while (fgets(buf, sizeof(buf), fp) != NULL) {
+			if (strstr(buf, kernel_opt1) != NULL) {
+				found_opt1 = 1;
+			}
+			if (strstr(buf, kernel_opt2) != NULL) {
+				found_opt2 = 1;
+			}
+			if (found_opt1 && found_opt2) {
+				dmabuf_supported = 1;
+				break;
+			}
+		}
+		fclose(fp);
+	}
+#endif
+
 	return SUCCESS;
 }
 
@@ -85,11 +133,42 @@ int rocm_memory_allocate_buffer(struct memory_ctx *ctx, int alignment, uint64_t 
 	hipError_t error;
 	size_t buf_size = (size + ACCEL_PAGE_SIZE - 1) & ~(ACCEL_PAGE_SIZE - 1);
 
+	struct rocm_memory_ctx *rocm_ctx = container_of(ctx, struct rocm_memory_ctx, base);
 	error = hipMalloc(&d_A, buf_size);
 	if (error != hipSuccess) {
 		printf("hipMalloc error=%d\n", error);
 		return FAILURE;
 	}
+
+#ifdef HAVE_ROCM_DMABUF
+	if (rocm_ctx->use_dmabuf) {
+		hipDeviceptr_t aligned_ptr;
+		const size_t host_page_size = sysconf(_SC_PAGESIZE);
+		uint64_t offset;
+		size_t aligned_size;
+		hsa_status_t status;
+
+		// Round down to host page size
+		aligned_ptr = (hipDeviceptr_t)((uintptr_t)d_A & ~(host_page_size - 1));
+		offset = d_A - aligned_ptr;
+		aligned_size = (size + offset + host_page_size - 1) & ~(host_page_size - 1);
+
+		printf("using DMA-BUF for GPU buffer address at %#llx aligned at %#llx with aligned size %zu\n", d_A, aligned_ptr, aligned_size);
+		*dmabuf_fd = 0;
+
+		status = hsa_amd_portable_export_dmabuf(d_A, aligned_size, dmabuf_fd, &offset);
+		if (status != HSA_STATUS_SUCCESS) {
+			printf("failed to export dmabuf handle for addr %p / %zu", d_A,
+					aligned_size);
+			return FAILURE;
+		}
+
+		printf("dmabuf export addr %p %lu to dmabuf fd %d offset %zu\n",
+				d_A, aligned_size, *dmabuf_fd, offset);
+
+		*dmabuf_offset = offset;
+	}
+#endif
 
 	printf("allocated %lu bytes of GPU buffer at %p\n", (unsigned long)buf_size, d_A);
 	*addr = d_A;
@@ -107,6 +186,14 @@ bool rocm_memory_supported() {
 	return true;
 }
 
+bool rocm_memory_dmabuf_supported() {
+#ifdef HAVE_ROCM_DMABUF
+	return true;
+#else
+	return false;
+#endif
+}
+
 struct memory_ctx *rocm_memory_create(struct perftest_parameters *params) {
 	struct rocm_memory_ctx *ctx;
 
@@ -119,6 +206,7 @@ struct memory_ctx *rocm_memory_create(struct perftest_parameters *params) {
 	ctx->base.copy_buffer_to_host = memcpy;
 	ctx->base.copy_buffer_to_buffer = memcpy;
 	ctx->device_id = params->rocm_device_id;
+	ctx->use_dmabuf = params->use_rocm_dmabuf;
 
 	return &ctx->base;
 }

--- a/src/rocm_memory.h
+++ b/src/rocm_memory.h
@@ -16,12 +16,18 @@ struct perftest_parameters;
 
 bool rocm_memory_supported();
 
+bool rocm_memory_dmabuf_supported();
+
 struct memory_ctx *rocm_memory_create(struct perftest_parameters *params);
 
 
 #ifndef HAVE_ROCM
 
 inline bool rocm_memory_supported() {
+	return false;
+}
+
+inline bool rocm_memory_dmabuf_supported() {
 	return false;
 }
 


### PR DESCRIPTION
Tracking Pak's PR to the upstream repo: https://github.com/linux-rdma/perftest/pull/309.
While we wait for changes to be merged to the upstream master branch, we will incorporate these changes in ROCm/rdma-perftest.
\
\
Enable DMABUF support in perftest for AMD GPU with ROCm

To build with ROCm DMA-BUF support, use:
`./configure --enable-rocm --with-rocm=/opt/rocm --enable-rocm-dmabuf`

To run with ROCm DMA-BUF enabled, use:
`ib_write_bw  --use_rocm_dmabuf --use_rocm=<rocm device id>`

An example to run ib_write_bw across 2 nodes using DMABUF:
```
# run server and client using -use_rocm_dmabuf --use_rocm=0:
$ ./ib_write_bw --use_rocm=0 --use_rocm_dmabuf -x 3 -a -F -q 2 --report_gbits -d bnxt_re0 -i 1
$ ./ib_write_bw --use_rocm=0 --use_rocm_dmabuf -x 3 -a -F -q 2 --report_gbits -d bnxt_re0 -i 1 <server>

************************************
* Waiting for client to connect... *
************************************
Using ROCm Device with ID: 0, Name: AMD Instinct MI300X, PCI Bus ID: 0x9, GCN Arch: gfx942:sramecc+:xnack-
using DMA-BUF for GPU buffer address at 0x7f0b71000000 aligned at 0x7f0b71000000 with aligned size 33554432
dmabuf export addr 0x7f0b71000000 33554432 to dmabuf fd 8 offset 0
allocated 33554432 bytes of GPU buffer at 0x7f0b71000000
Calling ibv_reg_dmabuf_mr(offset=0, size=33554432, addr=0x7f0b71000000, fd=8) for QP #0
---------------------------------------------------------------------------------------
                    RDMA_Write BW Test
 Dual-port       : OFF          Device         : bnxt_re0
 Number of qps   : 2            Transport type : IB
 Connection type : RC           Using SRQ      : OFF
 PCIe relax order: ON           Lock-free      : OFF
 ibv_wr* API     : OFF          Using DDP      : OFF
 CQ Moderation   : 100
 Mtu             : 4096[B]
 Link type       : Ethernet
 GID index       : 3
 Max inline data : 0[B]
 rdma_cm QPs     : OFF
 Use ROCm memory : ON
 Data ex. method : Ethernet
---------------------------------------------------------------------------------------
 local address: LID 0000 QPN 0x2c24 PSN 0x176c1e RKey 0x200ee18 VAddr 0x007f0b72000000
 GID: 00:00:00:00:00:00:00:00:00:00:255:255:192:168:07:11
 local address: LID 0000 QPN 0x2c27 PSN 0x8b66b0 RKey 0x200ee18 VAddr 0x007f0b72800000
 GID: 00:00:00:00:00:00:00:00:00:00:255:255:192:168:07:11
 remote address: LID 0000 QPN 0x2c6c PSN 0x7f0c60 RKey 0x200e718 VAddr 0x007f1ffae00000
 GID: 00:00:00:00:00:00:00:00:00:00:255:255:192:168:07:12
 remote address: LID 0000 QPN 0x2c6a PSN 0x7deeca RKey 0x200e718 VAddr 0x007f1ffb600000
 GID: 00:00:00:00:00:00:00:00:00:00:255:255:192:168:07:12
---------------------------------------------------------------------------------------
 #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]
 8388608    10000            392.33             392.33               0.005846
---------------------------------------------------------------------------------------
deallocating GPU buffer 0x7f0b71000000
```

An example for running with (previous/existing) peermem support, use `--use_rocm=<rocm device id>` without `--use_rocm_dmabuf` flag:
```
# for the previous/existing peermem support, run server and client using  --use_rocm=0:
$ ./ib_write_bw --use_rocm=0 -x 3 -a -F -q 2 --report_gbits -d bnxt_re0 -i 1
$ ./ib_write_bw --use_rocm=0 -x 3 -a -F -q 2 --report_gbits -d bnxt_re0 -i 1 <server>
************************************
* Waiting for client to connect... *
************************************
Using ROCm Device with ID: 0, Name: AMD Instinct MI300X, PCI Bus ID: 0x9, GCN Arch: gfx942:sramecc+:xnack-
allocated 33554432 bytes of GPU buffer at 0x7ecda9000000
---------------------------------------------------------------------------------------
                    RDMA_Write BW Test
 Dual-port       : OFF          Device         : bnxt_re0
 Number of qps   : 2            Transport type : IB
 Connection type : RC           Using SRQ      : OFF
 PCIe relax order: ON           Lock-free      : OFF
 ibv_wr* API     : OFF          Using DDP      : OFF
 CQ Moderation   : 100
 Mtu             : 4096[B]
 Link type       : Ethernet
 GID index       : 3
 Max inline data : 0[B]
 rdma_cm QPs     : OFF
 Use ROCm memory : ON
 Data ex. method : Ethernet
---------------------------------------------------------------------------------------
 local address: LID 0000 QPN 0x2c24 PSN 0x42d66 RKey 0x2011819 VAddr 0x007ecdaa000000
 GID: 00:00:00:00:00:00:00:00:00:00:255:255:192:168:07:11
 local address: LID 0000 QPN 0x2c27 PSN 0x606258 RKey 0x2011819 VAddr 0x007ecdaa800000
 GID: 00:00:00:00:00:00:00:00:00:00:255:255:192:168:07:11
 remote address: LID 0000 QPN 0x2c6c PSN 0x1ba0b6 RKey 0x200771b VAddr 0x007ec722e00000
 GID: 00:00:00:00:00:00:00:00:00:00:255:255:192:168:07:12
 remote address: LID 0000 QPN 0x2c6a PSN 0xb65b68 RKey 0x200771b VAddr 0x007ec723600000
 GID: 00:00:00:00:00:00:00:00:00:00:255:255:192:168:07:12
---------------------------------------------------------------------------------------
 #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]
 8388608    10000            392.34             392.34               0.005846
---------------------------------------------------------------------------------------
deallocating GPU buffer 0x7ecda9000000
```
